### PR TITLE
Adds raw value decoding

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -16,9 +16,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: k-arindam/setup-swift@v6.0.0
-      with:
-        swift-version: "6.0.0"
+#    - uses: k-arindam/setup-swift@v6.0.0
+#      with:
+#        swift-version: "6.0.0"
     
     - name: Get swift version
       run: swift --version

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,8 +1,5 @@
 Copyright © 2023 Ky Leggiero
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Usage of the works is permitted provided that this instrument is retained with the works, so that any entity that uses the works is notified of this instrument.
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
+DISCLAIMER: THE WORKS ARE WITHOUT WARRANTY.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,21 @@ Currently, these are supported:
         }
     }
     ```
+    - **`Decodable` – Decoding can accept raw values.** Of course, serialized data like the above are still decoded exactly as described. As of version 2.0.0, this can also be used to decode just the raw value itself, without specifying `"left"`/`"right"`:
+        ```json
+        {
+            "either": {
+                "name": "Dax",
+                "favoriteColor": 6765239
+            }
+        }
+        ```
+        or:
+        ```json
+        {
+            "right": 42
+        }
+        ```
 - **`Sendable`** Simply declares `Sendable` conformance when `Left` and `Right` are also `Sendable`
 
 

--- a/Sources/Either/Either + autoconformance.swift
+++ b/Sources/Either/Either + autoconformance.swift
@@ -212,16 +212,30 @@ extension Either: Encodable where Left: Encodable, Right: Encodable {
 
 extension Either: Decodable where Left: Decodable, Right: Decodable {
     public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKey.self)
-        
-        if let left = try container.decodeIfPresent(Left.self, forKey: .left) {
-            self = .left(left)
-        }
-        else if let right = try container.decodeIfPresent(Right.self, forKey: .right) {
-            self = .right(right)
+        if let container = try? decoder.container(keyedBy: CodingKey.self) {
+            
+            if let left = try container.decodeIfPresent(Left.self, forKey: .left) {
+                self = .left(left)
+            }
+            else if let right = try container.decodeIfPresent(Right.self, forKey: .right) {
+                self = .right(right)
+            }
+            else {
+                throw NeitherLeftNorRightValueWasEncoded()
+            }
         }
         else {
-            throw NeitherLeftNorRightValueWasEncoded()
+            let container = try decoder.singleValueContainer()
+            
+            if let left = try? container.decode(Left.self) {
+                self = .left(left)
+            }
+            else if let right = try? container.decode(Right.self) {
+                self = .right(right)
+            }
+            else {
+                throw NeitherLeftNorRightValueWasEncoded()
+            }
         }
     }
     

--- a/Sources/Either/Either + autoconformance.swift
+++ b/Sources/Either/Either + autoconformance.swift
@@ -216,26 +216,29 @@ extension Either: Decodable where Left: Decodable, Right: Decodable {
             
             if let left = try container.decodeIfPresent(Left.self, forKey: .left) {
                 self = .left(left)
+                return
             }
             else if let right = try container.decodeIfPresent(Right.self, forKey: .right) {
                 self = .right(right)
+                return
             }
             else {
-                throw NeitherLeftNorRightValueWasEncoded()
+                // try decoding a raw value
             }
         }
+        
+        // Raw value decoding
+        
+        let container = try decoder.singleValueContainer()
+        
+        if let left = try? container.decode(Left.self) {
+            self = .left(left)
+        }
+        else if let right = try? container.decode(Right.self) {
+            self = .right(right)
+        }
         else {
-            let container = try decoder.singleValueContainer()
-            
-            if let left = try? container.decode(Left.self) {
-                self = .left(left)
-            }
-            else if let right = try? container.decode(Right.self) {
-                self = .right(right)
-            }
-            else {
-                throw NeitherLeftNorRightValueWasEncoded()
-            }
+            throw NeitherLeftNorRightValueWasEncoded()
         }
     }
     

--- a/Tests/EitherTests/Either + autoconformance Tests.swift
+++ b/Tests/EitherTests/Either + autoconformance Tests.swift
@@ -336,7 +336,7 @@ final class Either___autoconformance_Tests: XCTestCase {
         
         
         
-        for _ in 1 ... 20 {
+        for _ in 1 ... 1000 {
             let either_TestCodable_Int_randomTest = CurrentEither.left(.init(
                 name: "Dax",
                 description: Bool.random() ? "A snepderg who helps others" : nil,
@@ -381,12 +381,20 @@ final class Either___autoconformance_Tests: XCTestCase {
         
         let payloadRight = try XCTUnwrap("""
         {
-            "value": 42
+            "value": {
+                "name": "Arc",
+                "favoriteNumber": 1981
+            }
         }
         """.data(using: .utf8))
         
+        struct ComplexStruct: Decodable, Equatable {
+            var name: String
+            var favoriteNumber: Int
+        }
+        
         struct TestStruct: Decodable {
-            var value: Either<String, Int>
+            var value: Either<String, ComplexStruct>
         }
         
         
@@ -396,7 +404,7 @@ final class Either___autoconformance_Tests: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(eitherLeft.left), "stringValue")
         
         let eitherRight = try decoder.decode(TestStruct.self, from: payloadRight).value
-        XCTAssertEqual(try XCTUnwrap(eitherRight.right), 42)
+        XCTAssertEqual(try XCTUnwrap(eitherRight.right), ComplexStruct(name: "Arc", favoriteNumber: 1981))
         
         XCTAssertNil(try decoder.decode(TestStruct.self, from: payloadRight).value.left, "Expected right-only either to be decoded, but somehow left-only either had a value.")
         XCTAssertNil(try decoder.decode(TestStruct.self, from: payloadLeft).value.right, "Expected left-only either to be decoded, but somehow right-only either had a value.")

--- a/Tests/EitherTests/Either + autoconformance Tests.swift
+++ b/Tests/EitherTests/Either + autoconformance Tests.swift
@@ -370,6 +370,37 @@ final class Either___autoconformance_Tests: XCTestCase {
             XCTAssertEqual(wrapped_randomInt, decoded_wrapped_randomInt)
         }
     }
+    
+    
+    func testDecodeRawValue() throws {
+        let payloadLeft = try XCTUnwrap("""
+        {
+            "value": "stringValue"
+        }
+        """.data(using: .utf8))
+        
+        let payloadRight = try XCTUnwrap("""
+        {
+            "value": 42
+        }
+        """.data(using: .utf8))
+        
+        struct TestStruct: Decodable {
+            var value: Either<String, Int>
+        }
+        
+        
+        let decoder = JSONDecoder()
+        
+        let eitherLeft = try decoder.decode(TestStruct.self, from: payloadLeft).value
+        XCTAssertEqual(try XCTUnwrap(eitherLeft.left), "stringValue")
+        
+        let eitherRight = try decoder.decode(TestStruct.self, from: payloadRight).value
+        XCTAssertEqual(try XCTUnwrap(eitherRight.right), 42)
+        
+        XCTAssertNil(try decoder.decode(TestStruct.self, from: payloadRight).value.left, "Expected right-only either to be decoded, but somehow left-only either had a value.")
+        XCTAssertNil(try decoder.decode(TestStruct.self, from: payloadLeft).value.right, "Expected left-only either to be decoded, but somehow right-only either had a value.")
+    }
 }
 
 


### PR DESCRIPTION
### Summary  
Now `Either` can be used to decode payloads which encode different types in the same field, without wrapping those fields in `"left"`/`"right"` sub-objects.

The decoder now attempts to interpret a single‑value container as the left type, and if that fails, the right type. Of course, if both fail to decode, then a `NeitherLeftNorRightValueWasEncoded` error is thrown just as always.

```swift
Either<String, Int>
```
```json
{ "value": "foo" }          // decodes to either.left("foo")
{ "value": 42 }             // decodes to either.right(42)
```

### Usage notes
Since this only depends on which types the field can encode as, this will always decode as `.left` when the left and right types of the `Either` are the same:

```swift
Either<String, String>
```
```json
{ "value": "foo" }          // decodes to either.left("foo")
{ "value": "baz" }          // decodes to either.left("baz")
```


## Breaking Changes  
While this update preserves existing decoding paths while adding an additional path, it does remove an error which might have previously been thrown. In case any users of this library depended on that error to validate encoded data which doesn't match their desired format, this change is considered breaking and requires a MAJOR version bump.